### PR TITLE
ダブルクォーテーション及び、カッコで括った文字列にカンマを入れられるように修正

### DIFF
--- a/Packages/SimpleCSVParser/Runtime/CsvParser.cs
+++ b/Packages/SimpleCSVParser/Runtime/CsvParser.cs
@@ -222,6 +222,8 @@ namespace Xeon.IO
                 return vector3Int.ToCsv(separator);
             if (value is Vector4 vector4)
                 return vector4.ToCsv(separator);
+            if (value is Quaternion quaternion)
+                return quaternion.ToCsv(separator);
             if (value is not string && value is IEnumerable enumerable)
             {
                 var array = new List<object>();

--- a/Packages/SimpleCSVParser/Runtime/CsvParser.cs.meta
+++ b/Packages/SimpleCSVParser/Runtime/CsvParser.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c60033352baca1c409d35e24b391b9ad
+guid: b2e54513ba6293c4cb012047272d7965
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/SimpleCSVParser/Runtime/CsvSupport.cs
+++ b/Packages/SimpleCSVParser/Runtime/CsvSupport.cs
@@ -19,6 +19,8 @@ namespace Xeon.IO
             => Format(new object[] { value.x, value.y, value.z }, separator);
         public static string ToCsv(this Vector4 value, string separator = ",")
             => Format(new object[] { value.x, value.y, value.z, value.w }, separator);
+        public static string ToCsv(this Quaternion value, string separator = ",")
+            => Format(new object[] { value.x, value.y, value.z, value.w }, separator);
 
         public static Vector2 ToVector2(this string self, string separator = ",")
         {
@@ -65,6 +67,18 @@ namespace Xeon.IO
                 && float.TryParse(splited[2], out var z)
                 && float.TryParse(splited[3], out var w))
                 return new Vector4(x, y, z, w);
+            throw new InvalidFormatException();
+        }
+
+        public static Quaternion ToQuaternion(this string self, string separator = ",")
+        {
+            var splited = Split(self, separator);
+            if (splited.Length <= 3) throw new InvalidFormatException();
+            if (   float.TryParse(splited[0], out var x)
+                && float.TryParse(splited[1], out var y)
+                && float.TryParse(splited[2], out var z)
+                && float.TryParse(splited[3], out var w))
+                return new Quaternion(x, y, z, w);
             throw new InvalidFormatException();
         }
 

--- a/Packages/SimpleCSVParser/Runtime/CsvSupport.cs
+++ b/Packages/SimpleCSVParser/Runtime/CsvSupport.cs
@@ -1,0 +1,76 @@
+using System;
+using UnityEngine;
+
+namespace Xeon.IO
+{
+    public class InvalidFormatException : Exception
+    {
+        public override string Message => "フォーマットが正しくありません";
+    }
+    public static class CsvSupport
+    {
+        public static string ToCsv(this Vector2 value, string separator = ",")
+            => Format(new object[] { value.x, value.y }, separator);
+        public static string ToCsv(this Vector2Int value, string separator = ",")
+            => Format(new object[] { value.x, value.y }, separator);
+        public static string ToCsv(this Vector3 value, string separator = ",")
+            => Format(new object[] { value.x, value.y, value.z }, separator);
+        public static string ToCsv(this Vector3Int value, string separator = ",")
+            => Format(new object[] { value.x, value.y, value.z }, separator);
+        public static string ToCsv(this Vector4 value, string separator = ",")
+            => Format(new object[] { value.x, value.y, value.z, value.w }, separator);
+
+        public static Vector2 ToVector2(this string self, string separator = ",")
+        {
+            var splited = Split(self, separator);
+            if (splited.Length <= 1) throw new InvalidFormatException();
+            if (float.TryParse(splited[0], out var x) && float.TryParse(splited[1], out var y))
+                return new Vector2(x, y);
+            throw new InvalidFormatException();
+        }
+
+        public static Vector2Int ToVector2Int(this string self, string separator = ",")
+        {
+            var splited = Split(self, separator);
+            if (splited.Length <= 1) throw new InvalidFormatException();
+            if (int.TryParse(splited[0], out var x) && int.TryParse(splited[1], out var y))
+                return new Vector2Int(x, y);
+            throw new InvalidFormatException();
+        }
+
+        public static Vector3 ToVector3(this string self, string separator = ",")
+        {
+            var splited = Split(self, separator);
+            if (splited.Length <= 2) throw new InvalidFormatException();
+            if (float.TryParse(splited[0], out var x) && float.TryParse(splited[1], out var y) && float.TryParse(splited[2], out var z))
+                return new Vector3(x, y, z);
+            throw new InvalidFormatException();
+        }
+
+        public static Vector3Int ToVector3Int(this string self, string separator = ",")
+        {
+            var splited = Split(self, separator);
+            if (splited.Length <= 2) throw new InvalidFormatException();
+            if (int.TryParse(splited[0], out var x) && int.TryParse(splited[1], out var y) && int.TryParse(splited[2], out var z))
+                return new Vector3Int(x, y, z);
+            throw new InvalidFormatException();
+        }
+
+        public static Vector4 ToVector4(this string self, string seprator = ",")
+        {
+            var splited = Split(self, seprator);
+            if (splited.Length <= 3) throw new InvalidFormatException();
+            if (   float.TryParse(splited[0], out var x)
+                && float.TryParse(splited[1], out var y)
+                && float.TryParse(splited[2], out var z)
+                && float.TryParse(splited[3], out var w))
+                return new Vector4(x, y, z, w);
+            throw new InvalidFormatException();
+        }
+
+        private static string Format(object[] values, string separator)
+            => $"({string.Join(separator, values)})";
+        private static string[] Split(string original, string separator)
+            => original.Trim('(', ')').Split(separator);
+    }
+}

--- a/Packages/SimpleCSVParser/Runtime/CsvSupport.cs.meta
+++ b/Packages/SimpleCSVParser/Runtime/CsvSupport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 985e671115d44664cb0f3490adf31ce0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/SimpleCSVParser/Test.meta
+++ b/Packages/SimpleCSVParser/Test.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1b7e42932f9a7814f82cd72fb301dd0c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/SimpleCSVParser/Test/CsvParseTest.cs
+++ b/Packages/SimpleCSVParser/Test/CsvParseTest.cs
@@ -1,7 +1,9 @@
 using NUnit.Framework;
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
 using UnityEngine;
 using Xeon.IO;
 
@@ -14,7 +16,7 @@ public class CsvParseTest
         Two,
     }
     [Serializable]
-    private class TestData
+    private class TestData : CsvData
     {
         [CsvColumn("int_value")]
         public int intValue;
@@ -44,7 +46,7 @@ public class CsvParseTest
             => this.privateValue = privateValue;
     }
     [Test]
-    public void ParseTest()
+    public void ToCsvTest()
     {
         var testData = new TestData(12)
         {
@@ -61,8 +63,39 @@ public class CsvParseTest
         };
         var csv = CsvParser.ToCSV(new List<TestData>(){ testData }, ",");
         var expect = @"int_value,float_value,string_value,bool_value,vector2_value,vector2int_value,vector3_value,vector3int_value,vector4_value,enum_value,private_int_value
-10,123.45,abcdefg,False,(10,10.5),(0,-1),(1.1,2.2,3.3),(1,1,1),(1.1,2.2,3.3,4),Two,12
+10,123.45,""abcdefg"",False,(10,10.5),(0,-1),(1.1,2.2,3.3),(1,1,1),(1.1,2.2,3.3,4),Two,12
 ";
         Assert.That(expect == csv);
+    }
+
+    [Test]
+    public void ParseFileTest()
+    {
+        var path = Application.dataPath.Replace("Assets", "");
+        path = Path.Combine(path, "Packages/SimpleCSVParser/Test/TestData/Test.csv");
+        var obj = CsvParser.ParseFile<TestData>(path, ",");
+        Debug.Log(obj.Count);
+    }
+
+    [Test]
+    public void ParseTest()
+    {
+        var csv = @"int_value,float_value,string_value,bool_value,vector2_value,vector2int_value,vector3_value,vector3int_value,vector4_value,enum_value,private_int_value
+10,123.45,""abcdefg"",False,(10,10.5),(0,-1),(1.1,2.2,3.3),(1,1,1),(1.1,2.2,3.3,4),Two,12
+";
+        var obj = CsvParser.Parse<TestData>(csv, ",");
+        Debug.Log(obj.Count);
+        Assert.That(obj.Count == 1);
+        var data = obj.First();
+        Assert.That(data.intValue == 10);
+        Assert.That(data.floatValue == 123.45f);
+        Assert.That(data.stringValue == "abcdefg");
+        Assert.That(data.boolValue == false);
+        Assert.That(data.vector2Value == new Vector2(10f, 10.5f));
+        Assert.That(data.vector2IntValue == Vector2Int.down);
+        Assert.That(data.vector3Value == new Vector3(1.1f, 2.2f, 3.3f));
+        Assert.That(data.vector3IntValue == Vector3Int.one);
+        Assert.That(data.vector4Value == new Vector4(1.1f, 2.2f, 3.3f, 4));
+        Assert.That(data.enumValue == TestEnum.Two);
     }
 }

--- a/Packages/SimpleCSVParser/Test/CsvParseTest.cs
+++ b/Packages/SimpleCSVParser/Test/CsvParseTest.cs
@@ -1,0 +1,68 @@
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Xeon.IO;
+
+public class CsvParseTest
+{
+    private enum TestEnum
+    {
+        Zero,
+        One,
+        Two,
+    }
+    [Serializable]
+    private class TestData
+    {
+        [CsvColumn("int_value")]
+        public int intValue;
+        [CsvColumn("float_value")]
+        public float floatValue;
+        [CsvColumn("string_value")]
+        public string stringValue;
+        [CsvColumn("bool_value")]
+        public bool boolValue;
+        [CsvColumn("vector2_value")]
+        public Vector2 vector2Value;
+        [CsvColumn("vector2int_value")]
+        public Vector2Int vector2IntValue;
+        [CsvColumn("vector3_value")]
+        public Vector3 vector3Value;
+        [CsvColumn("vector3int_value")]
+        public Vector3Int vector3IntValue;
+        [CsvColumn("vector4_value")]
+        public Vector4 vector4Value;
+        [CsvColumn("enum_value")]
+        public TestEnum enumValue;
+        [CsvColumn("private_int_value")]
+        private int privateValue;
+
+        public TestData() { }
+        public TestData(int privateValue)
+            => this.privateValue = privateValue;
+    }
+    [Test]
+    public void ParseTest()
+    {
+        var testData = new TestData(12)
+        {
+            intValue = 10,
+            floatValue = 123.45f,
+            stringValue = "abcdefg",
+            boolValue = false,
+            vector2Value = new Vector2(10f, 10.5f),
+            vector2IntValue = Vector2Int.down,
+            vector3Value = new Vector3(1.1f, 2.2f, 3.3f),
+            vector3IntValue = Vector3Int.one,
+            vector4Value = new Vector4(1.1f, 2.2f, 3.3f, 4),
+            enumValue = TestEnum.Two
+        };
+        var csv = CsvParser.ToCSV(new List<TestData>(){ testData }, ",");
+        var expect = @"int_value,float_value,string_value,bool_value,vector2_value,vector2int_value,vector3_value,vector3int_value,vector4_value,enum_value,private_int_value
+10,123.45,abcdefg,False,(10,10.5),(0,-1),(1.1,2.2,3.3),(1,1,1),(1.1,2.2,3.3,4),Two,12
+";
+        Assert.That(expect == csv);
+    }
+}

--- a/Packages/SimpleCSVParser/Test/CsvParseTest.cs.meta
+++ b/Packages/SimpleCSVParser/Test/CsvParseTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b28fb59222cb7cc45803edaf03c349b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/SimpleCSVParser/Test/CsvSupportTest.cs
+++ b/Packages/SimpleCSVParser/Test/CsvSupportTest.cs
@@ -1,0 +1,59 @@
+using NUnit.Framework;
+using UnityEngine;
+using Xeon.IO;
+
+public class CsvSupportTest
+{
+    [Test]
+    public void Vector2Test()
+    {
+        var vector2 = new Vector2(10.5f, 2.5f);
+        Assert.That(vector2.ToCsv() == "(10.5,2.5)");
+        Assert.That("(10,5.5)".ToVector2() == new Vector2(10f, 5.5f));
+        Assert.That("1,4".ToVector2() == new Vector2(1,4));
+        Assert.Throws<InvalidFormatException>(() => "(1)".ToVector2());
+        Assert.Throws<InvalidFormatException>(() => "1".ToVector2());
+    }
+
+    [Test]
+    public void Vector2IntTest()
+    {
+        var vector2Int = Vector2Int.one;
+        Assert.That(vector2Int.ToCsv() == "(1,1)");
+        Assert.That("(4,2)".ToVector2Int() == new Vector2Int(4, 2));
+        Assert.That("3,66".ToVector2Int() == new Vector2Int(3, 66));
+        Assert.Throws<InvalidFormatException>(() => "(1.1,4)".ToVector2Int());
+        Assert.Throws<InvalidFormatException>(() => "(1)".ToVector2Int());
+    }
+
+    [Test]
+    public void Vector3Test()
+    {
+        var vector3 = new Vector3(1.1f, 2.2f, 3.3f);
+        Assert.That(vector3.ToCsv() == "(1.1,2.2,3.3)");
+        Assert.That("(1,2.2,3.5)".ToVector3() == new Vector3(1f, 2.2f, 3.5f));
+        Assert.That("4.4,5,6.7".ToVector3() == new Vector3(4.4f, 5f, 6.7f));
+        Assert.Throws<InvalidFormatException>(() => "1,2".ToVector3());
+    }
+
+    [Test]
+    public void Vector3IntTest()
+    {
+        var vector3Int = new Vector3Int(1, 2, 3);
+        Assert.That(vector3Int.ToCsv() == "(1,2,3)");
+        Assert.That("(4,5,6)".ToVector3Int() == new Vector3Int(4, 5, 6));
+        Assert.That("7,8,9".ToVector3Int() == new Vector3Int(7, 8, 9));
+        Assert.Throws<InvalidFormatException>(() => "(1.1,2,3)".ToVector3Int());
+        Assert.Throws<InvalidFormatException>(() => "1,1".ToVector3Int());
+    }
+
+    [Test]
+    public void Vector4Test()
+    {
+        var vector4 = new Vector4(1.1f, 2.2f, 3.3f, 4f);
+        Assert.That(vector4.ToCsv() == "(1.1,2.2,3.3,4)");
+        Assert.That("(1,2,3,4.4)".ToVector4() == new Vector4(1f, 2f, 3f, 4.4f));
+        Assert.That("1.2,3,4,5".ToVector4() == new Vector4(1.2f, 3f, 4f, 5f));
+        Assert.Throws<InvalidFormatException>(() => "(1,2,3)".ToVector4());
+    }
+}

--- a/Packages/SimpleCSVParser/Test/CsvSupportTest.cs.meta
+++ b/Packages/SimpleCSVParser/Test/CsvSupportTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2952aab10c89b04291b936461d6945a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/SimpleCSVParser/Test/TestData.meta
+++ b/Packages/SimpleCSVParser/Test/TestData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8fd1f8c4dc8b2f4cb34b15ac0655d8b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/SimpleCSVParser/Test/TestData/Test.csv
+++ b/Packages/SimpleCSVParser/Test/TestData/Test.csv
@@ -1,0 +1,3 @@
+int_value,float_value,string_value,bool_value,vector2_value,vector2int_value,vector3_value,vector3int_value,vector4_value,enum_value,private_int_value
+10,123.45,"abcdefg",False,(10,10.5),(0,-1),(1.1,2.2,3.3),(1,1,1),(1.1,2.2,3.3,4),Two,12
+10,123.45,"two line\ntest",False,(10,10.5),(0,-1),(1.1,2.2,3.3),(1,1,1),(1.1,2.2,3.3,4),Two,12

--- a/Packages/SimpleCSVParser/Test/TestData/Test.csv.meta
+++ b/Packages/SimpleCSVParser/Test/TestData/Test.csv.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c3ad1c8fb73aa3d4e9ef478875f1ee96
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/SimpleCSVParser/Test/jp.co.xeon.simple_csv_parser.test.asmdef
+++ b/Packages/SimpleCSVParser/Test/jp.co.xeon.simple_csv_parser.test.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "jp.xeon.simple_csv_parser.test",
+    "rootNamespace": "",
+    "references": [
+        "GUID:132341a8f4c482f4cb07785897dd4652",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/SimpleCSVParser/Test/jp.co.xeon.simple_csv_parser.test.asmdef.meta
+++ b/Packages/SimpleCSVParser/Test/jp.co.xeon.simple_csv_parser.test.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 508b05b64ff04014288eccd2236fabd3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -247,7 +247,7 @@
       "url": "https://packages.unity.com"
     },
     "jp.xeon.simple_csv_parser": {
-      "version": "file:SimpleCSVParer",
+      "version": "file:SimpleCSVParser",
       "depth": 0,
       "source": "embedded",
       "dependencies": {


### PR DESCRIPTION
# 概要
現状では、カンマ区切りの複数のフィールドを持つVector3などのクラスがcsv形式では対応できておらず、tsv形式でのみの対応になってしまっていたので、csv形式でも対応できるようにエスケープ機能を追加。

他、以下実装
- テストコード追加
- Quaternion対応
- Vector4対応